### PR TITLE
Remove expire argument for url method and do not generate signed url for public/public-read bucket

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,17 @@ Use the following settings to authenticate with AliCloud OSS.
     # AliCloud access key secret
     OSS_ACCESS_KEY_SECRET = <Your Access Key Secret>
 
+Storage settings
+=======================
+
+For public or public-read buckets, storage urls will be bucket_name.endpoint/key format
+
+For private buckets, storage urls will be signed url. The expires time can be set by OSS_EXPIRE_TIME as environment variable or as Django settings. The default value for OSS_EXPIRE_TIME is 30 days.
+
+.. code-block:: bash
+
+    OSS_EXPIRE_TIME = <Expire Time in Seconds>
+
 File storage settings
 =====================
 

--- a/django_oss_storage/backends.py
+++ b/django_oss_storage/backends.py
@@ -61,7 +61,7 @@ class OssStorage(Storage):
         self.access_key_secret = access_key_secret if access_key_secret else _get_config('OSS_ACCESS_KEY_SECRET')
         self.end_point = _normalize_endpoint(end_point if end_point else _get_config('OSS_ENDPOINT'))
         self.bucket_name = bucket_name if bucket_name else _get_config('OSS_BUCKET_NAME')
-        self.expire_time = expire_time if expire_time else _get_config('OSS_EXPIRE_TIME', default=60*60*24*30)
+        self.expire_time = expire_time if expire_time else int(_get_config('OSS_EXPIRE_TIME', default=60*60*24*30))
 
         self.auth = Auth(self.access_key_id, self.access_key_secret)
         self.service = Service(self.auth, self.end_point)
@@ -202,7 +202,7 @@ class OssStorage(Storage):
         key = self._get_key_name(name)
 
         if self.bucket_acl == BUCKET_ACL_PRIVATE:
-            return self.bucket.sign_url('GET', key, expire=self.expire_time)
+            return self.bucket.sign_url('GET', key, expires=self.expire_time)
 
         scheme, endpoint = self.end_point.split('//')
         return urljoin(scheme + '//' + self.bucket_name + '.' + endpoint, key)

--- a/django_oss_storage/backends.py
+++ b/django_oss_storage/backends.py
@@ -197,7 +197,7 @@ class OssStorage(Storage):
         logger().debug("files: %s", files)
         return dirs, files
 
-    def url(self, name, expire=60*60*24):
+    def url(self, name, expire=60*60*24*30):
         key = self._get_key_name(name)
         return self.bucket.sign_url('GET', key, expire)
 

--- a/django_oss_storage/backends.py
+++ b/django_oss_storage/backends.py
@@ -197,7 +197,7 @@ class OssStorage(Storage):
         logger().debug("files: %s", files)
         return dirs, files
 
-    def url(self, name, expire):
+    def url(self, name, expire=60*60*24):
         key = self._get_key_name(name)
         return self.bucket.sign_url('GET', key, expire)
 

--- a/django_oss_storage/backends.py
+++ b/django_oss_storage/backends.py
@@ -197,9 +197,9 @@ class OssStorage(Storage):
         logger().debug("files: %s", files)
         return dirs, files
 
-    def url(self, name, expire=60*60*24*30):
+    def url(self, name):
         key = self._get_key_name(name)
-        return self.bucket.sign_url('GET', key, expire)
+        return self.bucket.sign_url('GET', key, expire=60*60*24*30)
 
     def delete(self, name):
         name = self._get_key_name(name)

--- a/django_oss_storage/backends.py
+++ b/django_oss_storage/backends.py
@@ -80,6 +80,9 @@ class OssStorage(Storage):
         input   : test.txt
         output  : media/test.txt
         """
+        # urljoin won't work if name is absolute path
+        name = name.lstrip('/')
+        
         base_path = force_text(self.location)
         final_path = urljoin(base_path + "/", name)
         name = os.path.normpath(final_path.lstrip('/'))

--- a/tests/django-oss-storage-test/tests.py
+++ b/tests/django-oss-storage-test/tests.py
@@ -87,17 +87,17 @@ class TestOssStorage(SimpleTestCase):
         with self.save_file():
             logging.info("content type: %s", default_storage.content_type("test.txt"))
             self.assertEqual(default_storage.open("test.txt").read(), b"test")
-            self.assertEqual(requests.get(default_storage.url("test.txt", 60)).content, b"test")
+            self.assertEqual(requests.get(default_storage.url("test.txt")).content, b"test")
 
     def test_save_big_file(self):
         with self.save_file(content=b"test" * 1000):
             logging.info("content type: %s", default_storage.content_type("test.txt"))
             self.assertEqual(default_storage.open("test.txt").read(), b"test" * 1000)
-            self.assertEqual(requests.get(default_storage.url("test.txt", 60)).content, b"test" * 1000)
+            self.assertEqual(requests.get(default_storage.url("test.txt")).content, b"test" * 1000)
 
     def test_url(self):
         with self.save_file():
-            url = default_storage.url("test.txt", 100)
+            url = default_storage.url("test.txt")
             logging.info("url: %s", url)
             response = requests.get(url)
 
@@ -110,7 +110,7 @@ class TestOssStorage(SimpleTestCase):
         logging.info("objname: %s", objname)
         with self.save_file(objname, content=u'我的座右铭') as name:
             self.assertEqual(name, objname)
-            url = default_storage.url(objname, 300)
+            url = default_storage.url(objname)
             logging.info("url: %s", url)
             response = requests.get(url)
             self.assertEqual(response.status_code, 200)
@@ -229,7 +229,7 @@ class TestOssStorage(SimpleTestCase):
 
     def test_static_url(self):
         with self.save_file(storage=staticfiles_storage):
-            url = staticfiles_storage.url("test.txt", 60)
+            url = staticfiles_storage.url("test.txt")
             logging.info("url: %s", url)
             response = requests.get(url)
 
@@ -239,7 +239,7 @@ class TestOssStorage(SimpleTestCase):
 
     def test_configured_url(self):
         with self.settings(MEDIA_URL= "/media/"), self.save_file():
-            url = default_storage.url("test.txt", 60)
+            url = default_storage.url("test.txt")
             logging.info("url: %s", url)
             response = requests.get(url)
 


### PR DESCRIPTION
- Trying to solve #2 #9. ```url``` method is not compatible with django's default ```Storage``` class since it should has only one required positional argument.

    - Environment variable ```OSS_EXPIRE_TIME``` in seconds can be set for url expire time.

    - If ```OSS_EXPIRE_TIME``` is not set, default value is ```60*60*24*30``` which is 30 days will be used.

- For public/public-read bucket, there is no need to use signed urls since it will generate unique url (Signature parameter in url will change each time) each time. This makes CDN or brower cache unavailable. Since OSS ususally serves as static/media file serving purpose, it is better to use constant urls for public/public-read buckets.




