### PR TITLE
Fix non-existed file is improperly considered as existed when running collectstatic

### DIFF
--- a/django_oss_storage/backends.py
+++ b/django_oss_storage/backends.py
@@ -130,7 +130,7 @@ class OssStorage(Storage):
         if name.endswith("/"):
             # This looks like a directory, but OSS has no concept of directories
             # need to check whether the key starts with this prefix
-            result = self.bucket.list_objects(prefix=target_name, delimiter='', marker='', max_keys=1)
+            result = self.bucket.list_objects(prefix=target_name + '/', delimiter='', marker='', max_keys=1)
             if len(result.object_list) == 0:
                 logger().debug("object list: %s", result.object_list)
             else:

--- a/django_oss_storage/backends.py
+++ b/django_oss_storage/backends.py
@@ -130,7 +130,7 @@ class OssStorage(Storage):
         if name.endswith("/"):
             # This looks like a directory, but OSS has no concept of directories
             # need to check whether the key starts with this prefix
-            result = self.bucket.list_objects(prefix=target_name + '/', delimiter='', marker='', max_keys=1)
+            result = self.bucket.list_objects(prefix=target_name, delimiter='', marker='', max_keys=1)
             if len(result.object_list) == 0:
                 logger().debug("object list: %s", result.object_list)
             else:

--- a/django_oss_storage/backends.py
+++ b/django_oss_storage/backends.py
@@ -83,6 +83,10 @@ class OssStorage(Storage):
         final_path = urljoin(base_path + "/", name)
         name = os.path.normpath(final_path.lstrip('/'))
 
+        # Add / to the end of path since os.path.normpath will remove it
+        if final_path.endswith('/') and not name.endswith('/'):
+            name += '/'
+
         if six.PY2:
             name = name.encode('utf-8')
         return name


### PR DESCRIPTION
Step to reproduce:

- For example, if ```file_example2``` already exists in OSS, ```exists()``` function will return True for file ```file_example``` even though it is not. Then ```collectstatic``` will try to get meta data of this file and then error will be raised since file does not actually exist.

Reason:

- It is because in Linux (maybe also in Windows), ```os.path.normpath``` will remove ```/``` which is at the end of path. For example, ```/path/path/``` will be normalized to ```/path/path```. So the ```exits()``` method which checks existence of a folder by ```self.bucket.list_objects(prefix='/path/path/', delimiter='', marker='', max_keys=1)``` is actually checking by ```self.bucket.list_objects(prefix='/path/path', delimiter='', marker='', max_keys=1)``` without ```/``` at the end of ```prefix```

How to fix:

- It is fixed by appending / to the end of path if original path is ends with ```/```.