### PR TITLE
Stored filenames with forward slashes, even on Windows.

### DIFF
--- a/django_oss_storage/backends.py
+++ b/django_oss_storage/backends.py
@@ -85,7 +85,8 @@ class OssStorage(Storage):
 
         if six.PY2:
             name = name.encode('utf-8')
-        return name
+        # Store filenames with forward slashes, even on Windows.
+        return name.replace('\\', '/')
 
     def _open(self, name, mode='rb'):
         logger().debug("name: %s, mode: %s", name, mode)


### PR DESCRIPTION
Try to fix issue https://github.com/aliyun/django-oss-storage/issues/7 