### PR TITLE
Fix "cannot import name 'force_text'" error to support Django > 4.0

### DIFF
--- a/django_oss_storage/backends.py
+++ b/django_oss_storage/backends.py
@@ -14,7 +14,7 @@ from django.core.files import File
 from django.core.exceptions import ImproperlyConfigured, SuspiciousOperation
 from django.core.files.storage import Storage
 from django.conf import settings
-from django.utils.encoding import force_text, force_bytes
+from django.utils.encoding import force_str, force_bytes
 from django.utils.deconstruct import deconstructible
 from django.utils.timezone import utc
 from tempfile import SpooledTemporaryFile
@@ -83,7 +83,7 @@ class OssStorage(Storage):
         # urljoin won't work if name is absolute path
         name = name.lstrip('/')
 
-        base_path = force_text(self.location)
+        base_path = force_str(self.location)
         final_path = urljoin(base_path + "/", name)
         name = os.path.normpath(final_path.lstrip('/'))
 


### PR DESCRIPTION
The "ImportError: cannot import name 'force_text' from 'django.utils.encoding'" error occurs when a package or module tries to import the force_text function from Django's encoding module, but the function has been removed and replaced with force_str in Django version 4.
@huiguangjun @baiyubin