### PR TITLE
fix: support by django4+ versions

### DIFF
--- a/django_oss_storage/backends.py
+++ b/django_oss_storage/backends.py
@@ -14,11 +14,17 @@ from django.core.files import File
 from django.core.exceptions import ImproperlyConfigured, SuspiciousOperation
 from django.core.files.storage import Storage
 from django.conf import settings
-from django.utils.encoding import force_text, force_bytes
+try:
+    from django.utils.encoding import force_text
+except ImportError:
+    from django.utils.encoding import force_str as force_text
 from django.utils.deconstruct import deconstructible
-from django.utils.timezone import utc
+try:
+    from django.utils.timezone import utc
+except ImportError:
+    from datetime import timezone
+    utc = timezone.utc
 from tempfile import SpooledTemporaryFile
-
 import oss2.utils
 import oss2.exceptions
 from oss2 import Auth, Service, Bucket, ObjectIterator, BUCKET_ACL_PRIVATE

--- a/tests/django-oss-storage-test/tests.py
+++ b/tests/django-oss-storage-test/tests.py
@@ -14,7 +14,12 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.storage import default_storage
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.utils import timezone
-from django.utils.timezone import is_naive, make_naive, utc
+from django.utils.timezone import is_naive, make_naive
+try:
+    from django.utils.timezone import utc
+except ImportError:
+    from datetime import timezone
+    utc = timezone.utc
 from django_oss_storage.backends import OssError, OssMediaStorage, OssStaticStorage, OssStorage, _get_config
 from django_oss_storage import defaults
 from oss2 import to_unicode


### PR DESCRIPTION
🐞 fix: `force_text`
```
from django.utils.encoding import force_str as force_text
```

🐞 fix: `utc`
```
from datetime import timezone
utc = timezone.utc
```