### PR TITLE
Update to replace force_text to force_str, replace datetime.timezone.…

### DIFF
--- a/django_oss_storage/backends.py
+++ b/django_oss_storage/backends.py
@@ -14,9 +14,11 @@ from django.core.files import File
 from django.core.exceptions import ImproperlyConfigured, SuspiciousOperation
 from django.core.files.storage import Storage
 from django.conf import settings
-from django.utils.encoding import force_text, force_bytes
+# updated to replace force_text with force_str due to django new version deprecated this function
+from django.utils.encoding import force_str, force_bytes
 from django.utils.deconstruct import deconstructible
-from django.utils.timezone import utc
+# updated to replace django.utils.timezone with datetime.timezone.utc due to django new version deprecated this function
+import datetime
 from tempfile import SpooledTemporaryFile
 
 import oss2.utils
@@ -83,7 +85,7 @@ class OssStorage(Storage):
         # urljoin won't work if name is absolute path
         name = name.lstrip('/')
 
-        base_path = force_text(self.location)
+        base_path = force_str(self.location)
         final_path = urljoin(base_path + "/", name)
         name = os.path.normpath(final_path.lstrip('/'))
 
@@ -174,7 +176,7 @@ class OssStorage(Storage):
         file_meta = self.get_file_meta(name)
 
         if settings.USE_TZ:
-            return datetime.utcfromtimestamp(file_meta.last_modified).replace(tzinfo=utc)
+            return datetime.utcfromtimestamp(file_meta.last_modified).replace(tzinfo=datetime.timezone.utc)
         else:
             return datetime.fromtimestamp(file_meta.last_modified)
 


### PR DESCRIPTION
Current code cannot compitable with new django version,  update to fix it. 
force_text -> force_str
django.utils.timezone.utc to datetime.timezone.utc